### PR TITLE
Added support for boost 1.59 and 1.60

### DIFF
--- a/include/cucumber-cpp/internal/drivers/BoostDriver.hpp
+++ b/include/cucumber-cpp/internal/drivers/BoostDriver.hpp
@@ -13,7 +13,7 @@ protected:
     const InvokeResult invokeStepBody();
 
 private:
-    void initBoostTest();
+    static void initBoostTest();
     void runWithMasterSuite();
 };
 

--- a/tests/integration/drivers/BoostDriverTest.cpp
+++ b/tests/integration/drivers/BoostDriverTest.cpp
@@ -1,4 +1,7 @@
+#include <boost/version.hpp>
+
 #include <boost/test/unit_test.hpp>
+
 #include <cucumber-cpp/defs.hpp>
 
 #include "../../utils/DriverTestRunner.hpp"
@@ -25,6 +28,18 @@ THEN(PENDING_MATCHER_2) {
 
 using namespace cucumber::internal;
 
+#if BOOST_VERSION >= 105900
+namespace boost {
+    namespace unit_test {
+        namespace framework {
+            bool is_initialized() {
+                return boost::unit_test::framework::master_test_suite().argc > 0; 
+            }
+        }
+    }
+}
+#endif
+
 class BoostStepDouble : public BoostStep {
 public:
     const InvokeResult invokeStepBody() {
@@ -47,7 +62,7 @@ private:
         using namespace boost::unit_test;
         BoostStepDouble step;
         expectFalse("Framework is not initialized before the first test", framework::is_initialized());
-	step.invokeStepBody();
+        step.invokeStepBody();
         expectTrue("Framework is initialized after the first test", framework::is_initialized());
     }
 };


### PR DESCRIPTION
Adapted code to API changes in boost 1.59 and 1.60:
- Register global test case during initialization only (adding test
  case later does not work any longer) and exchange step body function
  dynamically instead.
- Replacement for removed
  boost::test::unit_test::framework::is_initialized()
